### PR TITLE
Support MacOSX.

### DIFF
--- a/dired-icon.el
+++ b/dired-icon.el
@@ -211,8 +211,7 @@ that kill lines."
   "Create or replace the `dired-icon--osx-executable' executable using the latest code."
   (interactive)
   (let ((default-directory dired-icon--script-directory))
-    (shell-command (concat "clang -O3 -framework CoreServices -framework AppKit get-icon-path-osx.m -o " (shell-quote-argument dired-icon--osx-executable)))
-    (expand-file-name dired-icon--osx-executable)))
+    (shell-command (concat "clang -O3 -framework CoreServices -framework AppKit get-icon-path-osx.m -o " (shell-quote-argument dired-icon--osx-executable)))))
 
 (defun dired-icon--get-icons-osx (file-names)
   (when (or (executable-find (expand-file-name dired-icon--osx-executable dired-icon--script-directory))
@@ -225,9 +224,8 @@ that kill lines."
       (when dired-files-string
         (setq icon-files-string (shell-command-to-string (format "%s \"%s\" \"%s\" \"%s\"" (expand-file-name dired-icon--osx-executable dired-icon--script-directory) dired-files-string dired-icon--osx-cache-dir (number-to-string dired-icon-gtk-image-size))))
 
-        (let ((icon-images nil)
-              (icon-files (reverse (split-string icon-files-string "\n" nil))))
-          (dolist (icon-fname icon-files)
+        (let ((icon-images nil))
+          (dolist (icon-fname (reverse (split-string icon-files-string "\n" nil)))
             (if (string= icon-fname "")
                 (push nil icon-images)
               (let ((image (gethash icon-fname dired-icon--image-hash)))

--- a/dired-icon.el
+++ b/dired-icon.el
@@ -137,7 +137,10 @@ recommended."
         ;; it.
         (pop icon-images)
         (cl-pairlis file-names icon-images))))
-   (t  ;; other unsupported systems
+   ;; MacOSX
+   ((and (equal system-type 'darwin))
+    (dired-icon--get-icons-osx file-names))
+   (t ;; other unsupported systems
     (cl-pairlis file-names
                 (make-list (length file-names) nil)))))
 
@@ -195,6 +198,44 @@ that kill lines."
                        (push #'dired-icon--update-upon-kill
                              (overlay-get o 'modification-hooks))
                        (push o dired-icon--overlays)))))))))
+
+;;; MacOSX variables
+(defvar dired-icon--osx-executable "dired-icon-osx-exe"
+  "Exe used to get file icon for OSX")
+
+(defvar dired-icon--osx-cache-dir (file-name-as-directory (expand-file-name "macosxcache" dired-icon--script-directory))
+  "Icon image cache directory for OSX")
+
+;;; MacOSX functions
+(defun dired-icon--osx-recompile ()
+  "Create or replace the `dired-icon--osx-executable' executable using the latest code."
+  (interactive)
+  (let ((default-directory dired-icon--script-directory))
+    (shell-command (concat "clang -O3 -framework CoreServices -framework AppKit get-icon-path-osx.m -o " (shell-quote-argument dired-icon--osx-executable)))
+    (expand-file-name dired-icon--osx-executable)))
+
+(defun dired-icon--get-icons-osx (file-names)
+  (when (or (executable-find (expand-file-name dired-icon--osx-executable dired-icon--script-directory))
+            (executable-find dired-icon--osx-executable)
+            (dired-icon--osx-recompile))
+    (let ((dired-files-string)
+          (icon-files-string))
+      (dolist (fn file-names)
+        (setq dired-files-string (concat dired-files-string fn "\n")))
+      (when dired-files-string
+        (setq icon-files-string (shell-command-to-string (format "%s \"%s\" \"%s\" \"%s\"" (expand-file-name dired-icon--osx-executable dired-icon--script-directory) dired-files-string dired-icon--osx-cache-dir (number-to-string dired-icon-gtk-image-size))))
+
+        (let ((icon-images nil)
+              (icon-files (reverse (split-string icon-files-string "\n" nil))))
+          (dolist (icon-fname icon-files)
+            (if (string= icon-fname "")
+                (push nil icon-images)
+              (let ((image (gethash icon-fname dired-icon--image-hash)))
+                (unless image
+                  (setq image (create-image icon-fname))
+                  (puthash icon-fname image dired-icon--image-hash))
+                (push image icon-images))))
+          (cl-pairlis file-names icon-images))))))
 
 ;;;###autoload
 (define-minor-mode dired-icon-mode

--- a/get-icon-path-osx.m
+++ b/get-icon-path-osx.m
@@ -1,0 +1,132 @@
+// Copyright (C) 2016  Shuai Zhao <slege_tank@163.com>
+//
+// This file is not part of GNU Emacs.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Use CoreService framework to get icon for file, and cache it.
+
+#import <Foundation/Foundation.h>
+#import <CoreServices/CoreServices.h>
+#import <AppKit/AppKit.h>
+#import <CommonCrypto/CommonCrypto.h>
+
+NSArray * cachedImageNameArray;
+NSString * cachedImageDir;
+
+
+/**
+ Generate NSBitImageRep.
+
+ @param image Input image
+ @return ImageRep
+ */
+NSBitmapImageRep * scaleBitmapImageRep(NSImage * image)
+{
+    NSBitmapImageRep *rep = [[NSBitmapImageRep alloc]
+                             initWithBitmapDataPlanes:NULL
+                             pixelsWide:image.size.width
+                             pixelsHigh:image.size.height
+                             bitsPerSample:8
+                             samplesPerPixel:4
+                             hasAlpha:YES
+                             isPlanar:NO
+                             colorSpaceName:NSDeviceRGBColorSpace
+                             bytesPerRow:image.size.width*4
+                             bitsPerPixel:32];
+
+    NSGraphicsContext * ctx = [NSGraphicsContext graphicsContextWithBitmapImageRep: rep];
+    [NSGraphicsContext saveGraphicsState];
+    [NSGraphicsContext setCurrentContext:ctx];
+    [image drawAtPoint:NSZeroPoint fromRect:NSZeroRect operation:NSCompositingOperationCopy fraction:1.0];
+    [ctx flushGraphics];
+    [NSGraphicsContext restoreGraphicsState];
+
+    return rep;
+}
+
+
+/**
+ Generate MD5 of the imageData.
+
+ @param imageData Image data
+ @return MD5
+ */
+NSString * MD5ForData(NSData * imageData)
+{
+    unsigned char result[CC_MD5_DIGEST_LENGTH];
+    CC_MD5([imageData bytes], (CC_LONG)[imageData length], result);
+    return [NSString stringWithFormat:
+            @"%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
+            result[0], result[1], result[2], result[3],
+            result[4], result[5], result[6], result[7],
+            result[8], result[9], result[10], result[11],
+            result[12], result[13], result[14], result[15]
+            ];
+}
+
+
+/**
+ Get file's icon and cache it.
+
+ @param filePath File's path.
+ @param size Image size.
+ @return Path of the cache icon.
+ */
+NSString * IconForFile(NSString * filePath, NSString * size)
+{
+    NSImage * image = [[NSWorkspace sharedWorkspace] iconForFile:filePath];
+    image.size = NSMakeSize([size floatValue], [size floatValue]);
+
+    NSBitmapImageRep * rep = scaleBitmapImageRep(image);
+
+    // Cache image to file
+    NSDictionary *imageProps = [NSDictionary dictionaryWithObject:[NSNumber numberWithFloat:1.0] forKey:NSImageCompressionFactor];
+    NSData *targetData = [rep representationUsingType:NSBitmapImageFileTypePNG properties:imageProps];
+    NSString * MD5 = MD5ForData(targetData);
+    NSString * cachePath = [cachedImageDir stringByAppendingPathComponent:MD5];
+    if (![cachedImageNameArray containsObject:MD5])
+    {
+        [targetData writeToFile:cachePath atomically:NO];
+    }
+
+    return cachePath;
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc < 4) return 0;
+    if (strlen(argv[1]) == 0 || strlen(argv[2]) == 0 || strlen(argv[3]) == 0) return 0;
+
+    NSArray * fileNames = [[[NSString stringWithUTF8String:argv[1]] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] componentsSeparatedByString:@"\n"];
+
+    cachedImageDir = [NSString stringWithUTF8String:argv[2]];
+
+    BOOL isDir = NO;
+    if (![[NSFileManager defaultManager] fileExistsAtPath:cachedImageDir isDirectory:&isDir] || !isDir)
+    {
+        if (![[NSFileManager defaultManager] createDirectoryAtPath:cachedImageDir withIntermediateDirectories:YES attributes:nil error:nil])
+        {
+            return 0;
+        }
+    }
+
+    cachedImageNameArray = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:cachedImageDir error:nil];
+
+    NSString * size = [NSString stringWithUTF8String:argv[3]];
+    for (NSString * fileName in fileNames)
+    {
+        printf("%s\n", [IconForFile(fileName, size) UTF8String]);
+    }
+}


### PR DESCRIPTION
Support MacOSX. Because there's no API to directly get a file's icon filepath, I have to cache them to disk.
The following is screenshots.

<img width="578" alt="1" src="https://cloud.githubusercontent.com/assets/4961343/23118926/08d2f374-f791-11e6-96f5-5552880faadb.png">
<img width="496" alt="2" src="https://cloud.githubusercontent.com/assets/4961343/23118927/091770da-f791-11e6-85aa-e08ab2358d07.png">

