### PR TITLE
Add space to string that is shown on mode line.

### DIFF
--- a/dired-icon.el
+++ b/dired-icon.el
@@ -245,7 +245,7 @@ that kill lines."
 ;;;###autoload
 (define-minor-mode dired-icon-mode
   "Display icons according to the file types in dired buffers."
-  :lighter "dired-icon"
+  :lighter " dired-icon"
   (if dired-icon-mode
       (progn
         (add-hook 'dired-before-readin-hook 'dired-icon--clear-icons t t)


### PR DESCRIPTION
For now `dired-icon' does not have space on the head.  I think space is necessary.